### PR TITLE
View hardware

### DIFF
--- a/src/slurmtui/css/slurmtui.css
+++ b/src/slurmtui/css/slurmtui.css
@@ -84,6 +84,14 @@ OldJobsScreen {
     background: $background 100%;
 }
 
+ResourcesScreen {
+    background: $background 100%;
+}
+
+PartitionDetailScreen {
+    background: $background 100%;
+}
+
 /* #button_THEME {
     height: 3;
     width: 30;

--- a/src/slurmtui/main.py
+++ b/src/slurmtui/main.py
@@ -17,6 +17,7 @@ from textual.widgets import Footer, Header
 from .screens import (
     InfoScreen,
     OldJobsScreen,
+    ResourcesScreen,
     SettingsScreen,
     SortableDataTable,
     get_confirm_screen,
@@ -73,6 +74,7 @@ class SlurmTUI(App[SlurmTUIReturn]):
         Binding("i", "info", "Info", key_display="I"),
         Binding("d", "delete", "Delete", key_display="D"),
         Binding("o", "old_jobs", "Old Jobs", key_display="O"),
+        Binding("r", "resources", "Resources", key_display="R"),
         Binding("s", "settings", "Settings", key_display="S"),
         Binding("q", "quit", "Quit", key_display="Q"),
         # fmt: on
@@ -482,6 +484,16 @@ class SlurmTUI(App[SlurmTUIReturn]):
         if self._update_timer is not None:
             self._update_timer.stop()
         await self.push_screen_wait(OldJobsScreen(settings=settings))
+        self._update_timer = self.set_timer(
+            self._effective_update_interval(), self._update_job_table
+        )
+
+    @work
+    async def action_resources(self) -> None:
+        """Show cluster resources."""
+        if self._update_timer is not None:
+            self._update_timer.stop()
+        await self.push_screen_wait(ResourcesScreen(settings=settings))
         self._update_timer = self.set_timer(
             self._effective_update_interval(), self._update_job_table
         )

--- a/src/slurmtui/screens/__init__.py
+++ b/src/slurmtui/screens/__init__.py
@@ -1,5 +1,6 @@
 from .confirm import get_confirm_screen
 from .info import InfoScreen
 from .old_jobs import OldJobsScreen
+from .resources import ResourcesScreen
 from .settings import SettingsScreen
 from .sortable_data_table import Sort, SortableDataTable

--- a/src/slurmtui/screens/resources.py
+++ b/src/slurmtui/screens/resources.py
@@ -16,7 +16,6 @@ from ..slurm_utils import (
     get_running_jobs,
 )
 from ..utils import SETTINGS
-
 from .sortable_data_table import SortableDataTable
 
 BAR_WIDTH = 20
@@ -154,6 +153,7 @@ class PartitionCard(Static):
             border_style="cyan",
             expand=True,
             title_align="left",
+            subtitle_align="left",
         )
 
     def on_click(self) -> None:
@@ -196,9 +196,7 @@ class PartitionDetailScreen(ModalScreen):
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        yield SortableDataTable(
-            zebra_stripes=True, id="partition_detail_table"
-        )
+        yield SortableDataTable(zebra_stripes=True, id="partition_detail_table")
         yield Footer()
 
     def on_mount(self) -> None:
@@ -240,12 +238,8 @@ class PartitionDetailScreen(ModalScreen):
             jobs_on_node = self.node_to_jobs.get(node_name, [])
             if jobs_on_node:
                 job_ids = ", ".join(str(j["job_id"]) for j in jobs_on_node)
-                users = ", ".join(
-                    sorted(set(j["user"] for j in jobs_on_node))
-                )
-                names = ", ".join(
-                    sorted(set(j["name"] for j in jobs_on_node))
-                )
+                users = ", ".join(sorted(set(j["user"] for j in jobs_on_node)))
+                names = ", ".join(sorted(set(j["name"] for j in jobs_on_node)))
             else:
                 job_ids = ""
                 users = ""
@@ -284,15 +278,11 @@ class PartitionDetailScreen(ModalScreen):
         node_name = self._node_names[row_idx]
         jobs_on_node = self.node_to_jobs.get(node_name, [])
         if not jobs_on_node:
-            self.notify(
-                f"No running jobs on {node_name}", severity="warning"
-            )
+            self.notify(f"No running jobs on {node_name}", severity="warning")
             return
 
         # Fetch the full job dict to pass to InfoScreen
-        all_jobs = get_running_jobs(
-            settings=self._get_all_jobs_settings()
-        )
+        all_jobs = get_running_jobs(settings=self._get_all_jobs_settings())
         if not all_jobs or isinstance(all_jobs, CommandNotFoundError):
             self.notify("Could not fetch job details", severity="error")
             return
@@ -300,9 +290,7 @@ class PartitionDetailScreen(ModalScreen):
         job_id = jobs_on_node[0]["job_id"]
         job_info = all_jobs.get(job_id)
         if not job_info:
-            self.notify(
-                f"Job {job_id} no longer in queue", severity="warning"
-            )
+            self.notify(f"Job {job_id} no longer in queue", severity="warning")
             return
 
         from .info import InfoScreen

--- a/src/slurmtui/screens/resources.py
+++ b/src/slurmtui/screens/resources.py
@@ -1,0 +1,381 @@
+from copy import deepcopy
+from typing import Any
+
+from rich.panel import Panel
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.css.query import NoMatches
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Header, Static
+
+from ..slurm_utils import (
+    CommandNotFoundError,
+    build_node_to_jobs,
+    get_resources,
+    get_running_jobs,
+)
+from ..utils import SETTINGS
+
+from .sortable_data_table import SortableDataTable
+
+BAR_WIDTH = 20
+
+
+def _make_bar(used: int, total: int, width: int = BAR_WIDTH) -> str:
+    """Create a Unicode progress bar with percentage."""
+    if total == 0:
+        return f"[dim]{'─' * width}[/dim]  [dim]N/A[/dim]"
+    pct = used / total
+    filled = int(pct * width)
+    empty = width - filled
+    if pct >= 0.9:
+        color = "red"
+    elif pct >= 0.7:
+        color = "yellow"
+    else:
+        color = "green"
+    bar = f"[{color}]{'━' * filled}[/{color}][dim]{'─' * empty}[/dim]"
+    return f"{bar} [bold]{pct:>4.0%}[/bold]"
+
+
+def _stat_items(items: list[tuple[str, int, str]]) -> str:
+    """Build a dot-separated stat string, skipping zero values."""
+    parts = []
+    for label, value, color in items:
+        if value:
+            parts.append(f"[{color}]{value}[/{color}] {label}")
+    return " · ".join(parts) if parts else "[dim]none[/dim]"
+
+
+def _format_mem(mb: int) -> str:
+    """Format memory in MB to a human-readable string."""
+    if mb >= 1024:
+        return f"{mb / 1024:.0f}G"
+    return f"{mb}M"
+
+
+def _state_color(state: str) -> str:
+    """Return a Rich color name for a node state string."""
+    s = state.upper()
+    if "DOWN" in s or "DRAIN" in s or "NOT_RESPONDING" in s:
+        return "red"
+    if "IDLE" in s:
+        return "cyan"
+    if "MIXED" in s:
+        return "yellow"
+    if "ALLOCATED" in s:
+        return "green"
+    return "white"
+
+
+# ── Partition card (clickable) ──────────────────────────────────────
+
+
+class PartitionCard(Static):
+    """A card widget displaying partition resource info with progress bars."""
+
+    DEFAULT_CSS = """
+        PartitionCard {
+            height: auto;
+            margin: 0 1 0 1;
+        }
+    """
+
+    def __init__(
+        self,
+        name: str,
+        data: dict,
+        has_gpus: bool,
+        node_to_jobs: dict,
+        settings: SETTINGS,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.partition_name = name
+        self.data = data
+        self.has_gpus = has_gpus
+        self.node_to_jobs = node_to_jobs
+        self.settings = settings
+
+    def render(self) -> Panel:
+        d = self.data
+        nodes_used = d["nodes_allocated"] + d["nodes_mixed"]
+        cpus_used = d["cpus_allocated"]
+
+        lines = []
+
+        # --- Nodes ---
+        node_stats = _stat_items(
+            [
+                ("allocated", d["nodes_allocated"], "green"),
+                ("idle", d["nodes_idle"], "cyan"),
+                ("mixed", d["nodes_mixed"], "yellow"),
+                ("other", d["nodes_other"], "red"),
+            ]
+        )
+        lines.append(
+            f"  [bold]Nodes[/bold]  {_make_bar(nodes_used, d['nodes_total'])}"
+            f"   {node_stats}  [dim]({d['nodes_total']} total)[/dim]"
+        )
+
+        # --- CPUs ---
+        cpu_stats = _stat_items(
+            [
+                ("used", cpus_used, "green"),
+                ("idle", d["cpus_idle"], "cyan"),
+                ("other", d["cpus_other"], "red"),
+            ]
+        )
+        lines.append(
+            f"  [bold]CPUs [/bold]  {_make_bar(cpus_used, d['cpus_total'])}"
+            f"   {cpu_stats}  [dim]({d['cpus_total']} total)[/dim]"
+        )
+
+        # --- GPUs / Features ---
+        if d["gpus_total"] > 0:
+            if d["gpu_type"] == "UNK":
+                gpu_type_str = f"[dim]{d['features']}[/dim]"
+            else:
+                gpu_type_str = f"[bright_magenta]{d['gpu_type']}[/bright_magenta]"
+            lines.append(
+                f"  [bold]GPUs [/bold]  {gpu_type_str}"
+                f"  ·  {d['gpus_per_node']}/node"
+                f"  ·  [bold]{d['gpus_total']}[/bold] total"
+            )
+        elif d.get("features"):
+            lines.append(f"  [bold]Info [/bold]  [dim]{d['features']}[/dim]")
+
+        content = "\n".join(lines)
+        return Panel(
+            content,
+            title=f"[bold]{self.partition_name}[/bold]",
+            subtitle="[dim]click to expand[/dim]",
+            border_style="cyan",
+            expand=True,
+            title_align="left",
+        )
+
+    def on_click(self) -> None:
+        self.app.push_screen(
+            PartitionDetailScreen(
+                self.partition_name, self.data, self.node_to_jobs, self.settings
+            )
+        )
+
+
+# ── Partition detail screen ─────────────────────────────────────────
+
+
+class PartitionDetailScreen(ModalScreen):
+    """Detail view showing all nodes in a partition with job info."""
+
+    BINDINGS = [
+        Binding("i", "info", "Job Info", key_display="I"),
+        Binding("escape", "screen.dismiss", "Go Back", key_display="Esc"),
+        Binding("q", "quit", "Quit", key_display="Q"),
+    ]
+
+    CSS_PATH = "../css/slurmtui.css"
+
+    def __init__(
+        self,
+        name: str,
+        data: dict,
+        node_to_jobs: dict,
+        settings: SETTINGS,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.partition_name = name
+        self.data = data
+        self.node_to_jobs = node_to_jobs
+        self.settings = settings
+        # Ordered list of node names matching table rows
+        self._node_names: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield SortableDataTable(
+            zebra_stripes=True, id="partition_detail_table"
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.title = f"SlurmTUI: {self.partition_name}"
+
+        table = self.query_one(SortableDataTable)
+        table.cursor_type = "row"
+
+        has_gres = any(ng["gres"] for ng in self.data["node_groups"])
+
+        columns = [
+            "Node",
+            "State",
+            "CPUs Used",
+            "CPUs Total",
+            "CPU %",
+            "Memory",
+            "Mem Used",
+        ]
+        if has_gres:
+            columns.extend(["GRES", "GRES Used"])
+        columns.append("Features")
+        columns.extend(["Job ID", "User", "Job Name"])
+
+        table.add_columns(*columns)
+
+        self._node_names = []
+        for ng in self.data["node_groups"]:
+            node_name = ng["node"]
+            self._node_names.append(node_name)
+            cpu_pct = (
+                f"{ng['cpus_allocated'] / ng['cpus_total'] * 100:.0f}%"
+                if ng["cpus_total"] > 0
+                else "N/A"
+            )
+            state_col = _state_color(ng["state"])
+
+            # Cross-reference with running jobs
+            jobs_on_node = self.node_to_jobs.get(node_name, [])
+            if jobs_on_node:
+                job_ids = ", ".join(str(j["job_id"]) for j in jobs_on_node)
+                users = ", ".join(
+                    sorted(set(j["user"] for j in jobs_on_node))
+                )
+                names = ", ".join(
+                    sorted(set(j["name"] for j in jobs_on_node))
+                )
+            else:
+                job_ids = ""
+                users = ""
+                names = ""
+
+            row = [
+                node_name,
+                f"[{state_col}]{ng['state']}[/{state_col}]",
+                str(ng["cpus_allocated"]),
+                str(ng["cpus_total"]),
+                cpu_pct,
+                _format_mem(ng["mem_total_mb"]),
+                _format_mem(ng["mem_alloc_mb"]),
+            ]
+            if has_gres:
+                row.extend([ng["gres"], ng["gres_used"]])
+            row.append(ng["features"])
+            row.extend([job_ids, users, names])
+
+            table.add_row(*row, key=node_name)
+
+    def action_info(self) -> None:
+        """Show full job info for the job running on the selected node."""
+        try:
+            table = self.query_one(SortableDataTable)
+        except NoMatches:
+            return
+
+        if not self._node_names:
+            return
+
+        row_idx = table.cursor_coordinate.row
+        if row_idx >= len(self._node_names):
+            return
+
+        node_name = self._node_names[row_idx]
+        jobs_on_node = self.node_to_jobs.get(node_name, [])
+        if not jobs_on_node:
+            self.notify(
+                f"No running jobs on {node_name}", severity="warning"
+            )
+            return
+
+        # Fetch the full job dict to pass to InfoScreen
+        all_jobs = get_running_jobs(
+            settings=self._get_all_jobs_settings()
+        )
+        if not all_jobs or isinstance(all_jobs, CommandNotFoundError):
+            self.notify("Could not fetch job details", severity="error")
+            return
+
+        job_id = jobs_on_node[0]["job_id"]
+        job_info = all_jobs.get(job_id)
+        if not job_info:
+            self.notify(
+                f"Job {job_id} no longer in queue", severity="warning"
+            )
+            return
+
+        from .info import InfoScreen
+
+        self.app.push_screen(InfoScreen(job_info))
+
+    def _get_all_jobs_settings(self) -> SETTINGS:
+        """Return a copy of settings with CHECK_ALL_JOBS enabled."""
+        s = deepcopy(self.settings)
+        s.CHECK_ALL_JOBS = True
+        return s
+
+    def action_quit(self) -> None:
+        from ..slurm_utils import SlurmTUIReturn
+
+        self.app.exit(SlurmTUIReturn("quit", {}))
+
+
+# ── Resources overview screen ───────────────────────────────────────
+
+
+class ResourcesScreen(ModalScreen):
+
+    BINDINGS = [
+        Binding("escape", "screen.dismiss", "Go Back", key_display="Esc"),
+        Binding("q", "quit", "Quit", key_display="Q"),
+    ]
+
+    CSS_PATH = "../css/slurmtui.css"
+
+    def __init__(self, settings: SETTINGS, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.settings = settings
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+
+        resources = get_resources(self.settings)
+
+        if isinstance(resources, CommandNotFoundError):
+            yield Static(f"[red]Error: {resources.message}[/red]")
+        elif not resources:
+            yield Static("[yellow]No resource information available[/yellow]")
+        else:
+            # Fetch all running jobs to cross-reference nodes
+            all_jobs_settings = deepcopy(self.settings)
+            all_jobs_settings.CHECK_ALL_JOBS = True
+            all_jobs = get_running_jobs(settings=all_jobs_settings)
+            if isinstance(all_jobs, CommandNotFoundError):
+                all_jobs = None
+            node_to_jobs = build_node_to_jobs(all_jobs)
+
+            has_gpus = any(p["gpus_total"] > 0 for p in resources.values())
+            with VerticalScroll():
+                for name in sorted(resources):
+                    yield PartitionCard(
+                        name,
+                        resources[name],
+                        has_gpus,
+                        node_to_jobs,
+                        self.settings,
+                    )
+
+        yield Footer()
+
+    def on_mount(self) -> None:
+        resources = get_resources(self.settings)
+        if resources and not isinstance(resources, CommandNotFoundError):
+            self.app.title = f"SlurmTUI Resources: {len(resources)} partitions"
+        else:
+            self.app.title = "SlurmTUI Resources"
+
+    def action_quit(self) -> None:
+        from ..slurm_utils import SlurmTUIReturn
+
+        self.app.exit(SlurmTUIReturn("quit", {}))

--- a/src/slurmtui/screens/resources.py
+++ b/src/slurmtui/screens/resources.py
@@ -6,6 +6,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
 from textual.css.query import NoMatches
+from textual.events import Key
 from textual.screen import ModalScreen
 from textual.widgets import Footer, Header, Static
 
@@ -71,13 +72,16 @@ def _state_color(state: str) -> str:
 # ── Partition card (clickable) ──────────────────────────────────────
 
 
-class PartitionCard(Static):
+class PartitionCard(Static, can_focus=True):
     """A card widget displaying partition resource info with progress bars."""
 
     DEFAULT_CSS = """
         PartitionCard {
             height: auto;
-            margin: 0 1 0 1;
+            margin: 0 2 0 2;
+        }
+        PartitionCard:focus {
+            border: none;
         }
     """
 
@@ -146,22 +150,55 @@ class PartitionCard(Static):
             lines.append(f"  [bold]Info [/bold]  [dim]{d['features']}[/dim]")
 
         content = "\n".join(lines)
+        if self.has_focus:
+            border = "bright_white"
+            title = f"[bold]▶ {self.partition_name}[/bold]"
+        else:
+            border = "cyan"
+            title = f"[bold]{self.partition_name}[/bold]"
         return Panel(
             content,
-            title=f"[bold]{self.partition_name}[/bold]",
-            subtitle="[dim]click to expand[/dim]",
-            border_style="cyan",
+            padding=(0, 0, 0, 0),
+            title=title,
+            subtitle="[dim]enter/click to expand[/dim]",
+            border_style=border,
             expand=True,
             title_align="left",
             subtitle_align="left",
         )
 
-    def on_click(self) -> None:
+    def _expand(self) -> None:
         self.app.push_screen(
             PartitionDetailScreen(
                 self.partition_name, self.data, self.node_to_jobs, self.settings
             )
         )
+
+    def on_click(self) -> None:
+        self._expand()
+
+    def on_key(self, event: Key) -> None:
+        cards = list(self.screen.query(PartitionCard))
+        idx = cards.index(self)
+        if event.key == "down":
+            event.stop()
+            event.prevent_default()
+            cards[(idx + 1) % len(cards)].focus()
+        elif event.key == "up":
+            event.stop()
+            event.prevent_default()
+            cards[(idx - 1) % len(cards)].focus()
+        elif event.key == "enter":
+            event.stop()
+            event.prevent_default()
+            self._expand()
+
+    def on_focus(self) -> None:
+        self.refresh()
+        self.scroll_visible()
+
+    def on_blur(self) -> None:
+        self.refresh()
 
 
 # ── Partition detail screen ─────────────────────────────────────────
@@ -362,6 +399,10 @@ class ResourcesScreen(ModalScreen):
             self.app.title = f"SlurmTUI Resources: {len(resources)} partitions"
         else:
             self.app.title = "SlurmTUI Resources"
+        # Focus the first card for keyboard navigation
+        cards = self.query(PartitionCard)
+        if cards:
+            cards.first().focus()
 
     def action_quit(self) -> None:
         from ..slurm_utils import SlurmTUIReturn

--- a/src/slurmtui/screens/settings.py
+++ b/src/slurmtui/screens/settings.py
@@ -174,6 +174,14 @@ class SettingsScreen(ModalScreen[bool]):
                     tooltip="JSON file path to substitute for sacct output (debug/testing)",
                 )
 
+            with Horizontal(classes="settings_row"):
+                yield Label("Debug Sinfo JSON Path", classes="settings_label")
+                yield Input(
+                    settings.DEBUG_SINFO_JSON_PATH or "",
+                    id="input_DEBUG_SINFO_JSON_PATH",
+                    tooltip="JSON file path to substitute for sinfo output (debug/testing)",
+                )
+
         yield Footer()
 
     def action_save_settings(self) -> None:
@@ -238,6 +246,9 @@ class SettingsScreen(ModalScreen[bool]):
 
         sacct_path = self.query_one("#input_DEBUG_SACCT_JSON_PATH", Input).value.strip()
         settings.DEBUG_SACCT_JSON_PATH = sacct_path or None
+
+        sinfo_path = self.query_one("#input_DEBUG_SINFO_JSON_PATH", Input).value.strip()
+        settings.DEBUG_SINFO_JSON_PATH = sinfo_path or None
 
         settings.save()
         self.notify("Settings saved")

--- a/src/slurmtui/slurm_utils.py
+++ b/src/slurmtui/slurm_utils.py
@@ -1,11 +1,12 @@
 import datetime
 import json
 import os
+import re
 import subprocess
 import sys
 from ast import literal_eval
 from functools import lru_cache
-from typing import Any, Dict
+from typing import Any, Dict, List, Tuple
 
 from .utils import SETTINGS, console
 
@@ -24,6 +25,14 @@ def get_fake_sacct(debug_sacct_json_path: str = None):
             return f.read()
     else:
         return json.dumps({"jobs": []})
+
+
+def get_fake_sinfo(debug_sinfo_json_path: str = None):
+    if debug_sinfo_json_path:
+        with open(debug_sinfo_json_path, "r") as f:
+            return f.read()
+    else:
+        return json.dumps({"sinfo": []})
 
 
 def get_time(time_field) -> str:
@@ -323,6 +332,190 @@ def get_job_resources(job_dict):
     if not job_dict or job_dict is None:
         return {}
     return job_dict.get("job_resources", {}) or {}
+
+
+def parse_gres_count(gres_str: str) -> Tuple[str, int]:
+    """Parse GRES string like 'gpu:8(S:0-1)' or 'gpu:h100:4(S:0-1)'.
+
+    Returns (gpu_type, count_per_node).
+    """
+    if not gres_str:
+        return ("", 0)
+    match = re.match(r"gpu:(?:(\w+):)?(\d+)", gres_str)
+    if match:
+        gpu_type = match.group(1) or "UNK"
+        count = int(match.group(2))
+        return (gpu_type, count)
+    return ("", 0)
+
+
+def get_resources(settings: SETTINGS) -> Dict[str, Dict]:
+    """Get cluster resource information from sinfo --json, aggregated by partition."""
+    if settings.MOCK:
+        raw = get_fake_sinfo(settings.DEBUG_SINFO_JSON_PATH)
+    else:
+        try:
+            raw = subprocess.check_output(
+                ["sinfo", "--json"], stderr=subprocess.DEVNULL
+            ).decode("utf-8")
+        except subprocess.CalledProcessError:
+            return None
+        except FileNotFoundError:
+            return CommandNotFoundError("`sinfo` command not found")
+
+    data = json.loads(raw)
+
+    partitions = {}
+    for entry in data.get("sinfo", []):
+        partition_name = entry["partition"]["name"]
+        if partition_name not in partitions:
+            partitions[partition_name] = {
+                "nodes_total": 0,
+                "nodes_allocated": 0,
+                "nodes_idle": 0,
+                "nodes_other": 0,
+                "nodes_mixed": 0,
+                "cpus_total": 0,
+                "cpus_allocated": 0,
+                "cpus_idle": 0,
+                "cpus_other": 0,
+                "gpus_per_node": 0,
+                "gpu_type": "",
+                "gpus_total": 0,
+                "features": "",
+                "node_groups": [],
+            }
+
+        p = partitions[partition_name]
+        nodes_in_group = entry["nodes"]["total"]
+        node_states = entry.get("node", {}).get("state", [])
+        is_mixed = "MIXED" in node_states
+
+        p["nodes_total"] += nodes_in_group
+        p["nodes_idle"] += entry["nodes"]["idle"]
+        p["nodes_other"] += entry["nodes"]["other"]
+
+        # In sinfo JSON, MIXED nodes are reported as "allocated" in the
+        # nodes breakdown.  Track them separately to avoid double-counting.
+        if is_mixed:
+            p["nodes_mixed"] += nodes_in_group
+        else:
+            p["nodes_allocated"] += entry["nodes"]["allocated"]
+
+        p["cpus_total"] += entry["cpus"]["total"]
+        p["cpus_allocated"] += entry["cpus"]["allocated"]
+        p["cpus_idle"] += entry["cpus"]["idle"]
+        p["cpus_other"] += entry["cpus"]["other"]
+
+        gres_total = entry.get("gres", {}).get("total", "")
+        gpu_type, gpu_count = parse_gres_count(gres_total)
+        if gpu_count > 0:
+            p["gpus_per_node"] = gpu_count
+            p["gpu_type"] = gpu_type
+            p["gpus_total"] += nodes_in_group * gpu_count
+
+        # Capture features as a fallback when no GPU GRES is present
+        features_total = entry.get("features", {}).get("total", "")
+        if features_total and not p["features"]:
+            p["features"] = features_total
+
+        # Collect per-node-group details for the detail view
+        memory = entry.get("memory", {})
+        mem_total = memory.get("maximum", 0)
+        mem_alloc = memory.get("allocated", 0)
+        node_names = entry.get("nodes", {}).get("nodes", [])
+        gres_used = entry.get("gres", {}).get("used", "")
+
+        for node_name in node_names:
+            p["node_groups"].append(
+                {
+                    "node": node_name,
+                    "state": ", ".join(node_states),
+                    "cpus_total": entry["cpus"]["total"] // max(nodes_in_group, 1),
+                    "cpus_allocated": entry["cpus"]["allocated"]
+                    // max(nodes_in_group, 1),
+                    "mem_total_mb": mem_total,
+                    "mem_alloc_mb": mem_alloc // max(nodes_in_group, 1),
+                    "gres": gres_total,
+                    "gres_used": gres_used,
+                    "features": features_total,
+                }
+            )
+
+    return partitions
+
+
+def expand_hostlist(hostlist: str) -> List[str]:
+    """Expand a Slurm compressed hostlist like 'node[1-3,5]' into individual names.
+
+    Handles formats: 'node1', 'node[1-3]', 'node[01-03,05]', 'r1i0n[0-35],r2i0n[0-35]',
+    and comma-separated bare names like 'node1,node2'.
+    """
+    if not hostlist or not hostlist.strip():
+        return []
+
+    results = []
+    # Tokenise: split on commas that are NOT inside brackets
+    depth = 0
+    current = []
+    for ch in hostlist:
+        if ch == "[":
+            depth += 1
+            current.append(ch)
+        elif ch == "]":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            results.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        results.append("".join(current))
+
+    expanded = []
+    for token in results:
+        m = re.match(r"^(.*?)\[([^\]]+)\](.*)$", token)
+        if not m:
+            expanded.append(token)
+            continue
+        prefix, range_spec, suffix = m.group(1), m.group(2), m.group(3)
+        for part in range_spec.split(","):
+            if "-" in part:
+                lo, hi = part.split("-", 1)
+                width = len(lo)
+                for i in range(int(lo), int(hi) + 1):
+                    expanded.append(f"{prefix}{str(i).zfill(width)}{suffix}")
+            else:
+                expanded.append(f"{prefix}{part}{suffix}")
+
+    return expanded
+
+
+def build_node_to_jobs(jobs_dict: Dict[int, Dict]) -> Dict[str, List[Dict]]:
+    """Build a mapping from node name to list of jobs running on it."""
+    node_to_jobs: Dict[str, List[Dict]] = {}
+    if not jobs_dict:
+        return node_to_jobs
+    for job in jobs_dict.values():
+        job_state = job.get("job_state", "")
+        if isinstance(job_state, list):
+            if not any(s == "RUNNING" for s in job_state):
+                continue
+        elif job_state != "RUNNING":
+            continue
+        nodes_str = str(job.get("nodes", ""))
+        for node in expand_hostlist(nodes_str):
+            node_to_jobs.setdefault(node, []).append(
+                {
+                    "job_id": job.get("job_id", ""),
+                    "user": job.get("user_name", ""),
+                    "name": str(job.get("name", ""))[:40],
+                    "partition": job.get("partition", ""),
+                    "job_state": job_state,
+                }
+            )
+    return node_to_jobs
 
 
 class SlurmTUIReturn:

--- a/src/slurmtui/utils.py
+++ b/src/slurmtui/utils.py
@@ -60,6 +60,9 @@ class SETTINGS:
     DEBUG_SACCT_JSON_PATH: Optional[str] = field(
         default=None, metadata="JSON file to substitute for sacct output"
     )
+    DEBUG_SINFO_JSON_PATH: Optional[str] = field(
+        default=None, metadata="JSON file to substitute for sinfo output"
+    )
 
     def save(self) -> None:
         SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -163,7 +166,7 @@ class SETTINGS:
                 data[key] = None
 
         # Optional str
-        for key in ("DEBUG_SQUEUE_JSON_PATH", "DEBUG_SACCT_JSON_PATH"):
+        for key in ("DEBUG_SQUEUE_JSON_PATH", "DEBUG_SACCT_JSON_PATH", "DEBUG_SINFO_JSON_PATH"):
             v = data.get(key)
             if v is not None and not isinstance(v, str):
                 data[key] = None


### PR DESCRIPTION
This pull request adds a new "Resources" screen to the SlurmTUI application, providing a cluster resource overview by partition. It introduces new utilities to parse and aggregate resource data from `sinfo --json`, adds debug support for fake sinfo data, and updates the settings screen to allow specifying a debug sinfo JSON path. Several helper functions for parsing and mapping cluster resources and jobs are also included.

**New Resources Screen and UI Integration:**
- Added a `ResourcesScreen` to display cluster resource information, including a new keybinding ("R") and action to launch the screen from the main UI. (`src/slurmtui/main.py`, `src/slurmtui/screens/__init__.py`, `src/slurmtui/css/slurmtui.css`) [[1]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR20) [[2]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR77) [[3]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR491-R500) [[4]](diffhunk://#diff-28c32857a5c63325dbc8f4e399772b8876c3129af7db1184ec7f9c211e5eeca8R4) [[5]](diffhunk://#diff-efb83dc51cb3d28f70f227d0029f0e97a5f8aee00730e54c35b5ff6ad9fe012fR87-R94)

**Cluster Resource Data Handling:**
- Implemented `get_resources` to parse and aggregate cluster resources from `sinfo --json`, grouped by partition, and added a `get_fake_sinfo` utility for debug/testing with mock data. (`src/slurmtui/slurm_utils.py`) [[1]](diffhunk://#diff-6c4c9b05fdfcf52daf01e8f891549368ef422257e6bddca7e6759c838a0fecddR30-R37) [[2]](diffhunk://#diff-6c4c9b05fdfcf52daf01e8f891549368ef422257e6bddca7e6759c838a0fecddR337-R520)
- Added helper functions: `parse_gres_count` (for GPU parsing), `expand_hostlist` (for hostlist expansion), and `build_node_to_jobs` (for mapping jobs to nodes). (`src/slurmtui/slurm_utils.py`)

**Settings and Debugging Enhancements:**
- Added a `DEBUG_SINFO_JSON_PATH` field to the `SETTINGS` class, updated validation, and extended the settings screen to allow users to set a debug sinfo JSON path for testing. (`src/slurmtui/utils.py`, `src/slurmtui/screens/settings.py`) [[1]](diffhunk://#diff-017298cf0570e02cef84da7dbab850c301b80bd7dcfc49e352b318025f5f2f4fR63-R65) [[2]](diffhunk://#diff-017298cf0570e02cef84da7dbab850c301b80bd7dcfc49e352b318025f5f2f4fL166-R169) [[3]](diffhunk://#diff-2f4c0938a9783dbc2a55b4b5358f2528f148249f31ec64eb078a0cf45368d71cR177-R184) [[4]](diffhunk://#diff-2f4c0938a9783dbc2a55b4b5358f2528f148249f31ec64eb078a0cf45368d71cR250-R252)