### PR TITLE
New features

### DIFF
--- a/src/slurmtui/main.py
+++ b/src/slurmtui/main.py
@@ -232,6 +232,7 @@ class SlurmTUI(App[SlurmTUIReturn]):
 
     def action_force_refresh(self) -> None:
         """Force an immediate refresh of the jobs table and reset the timer."""
+        self.notify("Refreshing jobs...", severity="information", timeout=1.5)
         if self._update_timer is not None:
             self._update_timer.stop()
         self._update_job_table()

--- a/src/slurmtui/main.py
+++ b/src/slurmtui/main.py
@@ -69,6 +69,7 @@ class SlurmTUI(App[SlurmTUIReturn]):
         # fmt: off
         Binding("l", "logs_out_tail", "Logs (STDOUT)", key_display="L"),
         Binding("e", "logs_err_tail", "Logs (STDERR)", key_display="E"),
+        Binding("ctrl+r", "force_refresh", "Force Refresh", key_display="Ctrl+R", show=False),
         Binding("ctrl+l", "logs_out_less", "Less of Logs (STDOUT)", key_display="Ctrl+L", show=False),
         Binding("ctrl+e", "logs_err_less", "Less of Logs (STDERR)", key_display="Ctrl+E", show=False),
         Binding("c", "connect", "Connect to Node (ssh)", key_display="C"),
@@ -228,6 +229,12 @@ class SlurmTUI(App[SlurmTUIReturn]):
         self._update_timer = self.set_timer(
             self._effective_update_interval(), self._update_job_table
         )
+
+    def action_force_refresh(self) -> None:
+        """Force an immediate refresh of the jobs table and reset the timer."""
+        if self._update_timer is not None:
+            self._update_timer.stop()
+        self._update_job_table()
 
     def on_mount(self) -> None:
         self.theme = settings.THEME

--- a/src/slurmtui/main.py
+++ b/src/slurmtui/main.py
@@ -17,6 +17,7 @@ from textual.widgets import Footer, Header
 
 from .screens import (
     InfoScreen,
+    LogPeekScreen,
     OldJobsScreen,
     ResourcesScreen,
     SettingsScreen,
@@ -72,6 +73,8 @@ class SlurmTUI(App[SlurmTUIReturn]):
         Binding("ctrl+r", "force_refresh", "Force Refresh", key_display="Ctrl+R", show=False),
         Binding("ctrl+l", "logs_out_less", "Less of Logs (STDOUT)", key_display="Ctrl+L", show=False),
         Binding("ctrl+e", "logs_err_less", "Less of Logs (STDERR)", key_display="Ctrl+E", show=False),
+        Binding("space", "peek_stdout", "Peek STDOUT", key_display="Space"),
+        Binding("ctrl+space", "peek_stderr", "Peek STDERR", key_display="Ctrl+Space", show=False),
         Binding("c", "connect", "Connect to Node (ssh)", key_display="C"),
         Binding("i", "info", "Info", key_display="I"),
         Binding("d", "delete", "Delete", key_display="D"),
@@ -357,6 +360,49 @@ class SlurmTUI(App[SlurmTUIReturn]):
         """Show the logs (STDERR) with less."""
         # get the id of the selected job
         self._get_log_screen(is_primary=False, is_std_out=False)
+
+    def _peek_log(self, is_std_out: bool) -> None:
+        """Show the last N lines of a log file in a popup."""
+        try:
+            job_table = self.query_one(SortableDataTable)
+            self.job_table = job_table
+        except NoMatches:
+            job_table = self.job_table
+
+        if self._check_no_jobs():
+            return
+
+        selected_job = list(self.running_jobs_dict.values())[
+            job_table.cursor_coordinate.row
+        ]
+
+        if check_for_state(selected_job["job_state"], "PENDING"):
+            self.notify(
+                f"Job {selected_job['job_id']} is in Pending state, no logs available!",
+                severity="warning",
+            )
+            return
+
+        log_path = selected_job["standard_output" if is_std_out else "standard_error"]
+
+        if not os.path.isfile(log_path):
+            self.notify(
+                "Log file not created yet or not found!" f"\n{log_path}",
+                severity="error",
+            )
+            return
+
+        stream = "STDOUT" if is_std_out else "STDERR"
+        title = f"Peek {stream}: {selected_job['name']} ({selected_job['job_id']})"
+        self.push_screen(LogPeekScreen(log_path, settings.PEEK_LINES, title))
+
+    def action_peek_stdout(self) -> None:
+        """Peek at the last N lines of STDOUT."""
+        self._peek_log(is_std_out=True)
+
+    def action_peek_stderr(self) -> None:
+        """Peek at the last N lines of STDERR."""
+        self._peek_log(is_std_out=False)
 
     def action_connect(self) -> None:
         """Connect to the node via SSH."""

--- a/src/slurmtui/screens/__init__.py
+++ b/src/slurmtui/screens/__init__.py
@@ -1,5 +1,6 @@
 from .confirm import get_confirm_screen
 from .info import InfoScreen
+from .log_peek import LogPeekScreen
 from .old_jobs import OldJobsScreen
 from .resources import ResourcesScreen
 from .settings import SettingsScreen

--- a/src/slurmtui/screens/log_peek.py
+++ b/src/slurmtui/screens/log_peek.py
@@ -1,0 +1,58 @@
+from collections import deque
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Header, RichLog
+
+
+class LogPeekScreen(ModalScreen[None]):
+    """Quick popup that shows the last N lines of a log file."""
+
+    DEFAULT_CSS = """
+    LogPeekScreen {
+        align: center middle;
+        background: $background 80%;
+    }
+
+    #log_peek_container {
+        width: 90%;
+        height: 85%;
+        border: thick $background 80%;
+        background: $surface;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "app.pop_screen", "Close", key_display="Esc"),
+        Binding("space", "app.pop_screen", "Close", key_display="Space"),
+        Binding("q", "app.pop_screen", "Close", key_display="Q"),
+    ]
+
+    def __init__(self, log_path: str, num_lines: int, title: str = "Log Peek") -> None:
+        super().__init__()
+        self.log_path = log_path
+        self.num_lines = num_lines
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield RichLog(
+            highlight=True,
+            markup=False,
+            auto_scroll=True,
+            wrap=True,
+            id="log_peek_container",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.title = self._title
+        rich_log = self.query_one(RichLog)
+        try:
+            with open(self.log_path, "r") as f:
+                lines = deque(f, maxlen=self.num_lines)
+            for line in lines:
+                rich_log.write(line.rstrip("\n"))
+        except Exception as e:
+            rich_log.write(f"Error reading log file: {e}")

--- a/src/slurmtui/screens/old_jobs.py
+++ b/src/slurmtui/screens/old_jobs.py
@@ -10,6 +10,7 @@ from textual.screen import ModalScreen
 from textual.widgets import Footer, Header
 
 from slurmtui.screens.info import InfoScreen
+from slurmtui.screens.log_peek import LogPeekScreen
 
 from ..slurm_utils import (
     SlurmTUIReturn,
@@ -91,6 +92,8 @@ class OldJobsScreen(ModalScreen):
         Binding("e", "logs_err_tail", "Logs (STDERR)", key_display="E"),
         Binding("ctrl+l", "logs_out_less", "Less of Logs (STDOUT)", key_display="Ctrl+L", show=False),
         Binding("ctrl+e", "logs_err_less", "Less of Logs (STDERR)", key_display="Ctrl+E", show=False),
+        Binding("space", "peek_stdout", "Peek STDOUT", key_display="Space"),
+        Binding("ctrl+space", "peek_stderr", "Peek STDERR", key_display="Ctrl+Space", show=False),
         Binding("i", "info", "Info", key_display="I"),
         Binding("s", "settings", "Settings", key_display="S"),
         Binding("q", "quit", "Quit", key_display="Q"),
@@ -291,6 +294,56 @@ class OldJobsScreen(ModalScreen):
         """Show the logs (STDERR) with less."""
         # get the id of the selected job
         self._get_log_screen(is_primary=False, is_std_out=False)
+
+    def _peek_log(self, is_std_out: bool) -> None:
+        """Show the last N lines of a log file in a popup."""
+        try:
+            job_table = self.query_one(SortableDataTable)
+            self.job_table = job_table
+        except NoMatches:
+            job_table = self.job_table
+
+        if self._check_no_jobs():
+            return
+
+        selected_job = list(self.old_jobs.values())[job_table.cursor_coordinate.row]
+
+        if check_for_state(selected_job["state"]["current"], "PENDING"):
+            self.notify(
+                f"Job {selected_job['job_id']} is in Pending state, no logs available!",
+                severity="warning",
+            )
+            return
+
+        key = "stdout_expanded" if is_std_out else "stderr_expanded"
+        if not selected_job.get(key, ""):
+            stream = "standard output" if is_std_out else "standard error"
+            self.notify(
+                f"Job {selected_job['job_id']} has no {stream}!. This may be due to slurm version being < 24.05",
+                severity="warning",
+            )
+            return
+
+        log_path = selected_job[key]
+
+        if not os.path.isfile(log_path):
+            self.notify(
+                "Log file not created yet or not found!" f"\n{log_path}",
+                severity="error",
+            )
+            return
+
+        stream = "STDOUT" if is_std_out else "STDERR"
+        title = f"Peek {stream}: {selected_job['name']} ({selected_job['job_id']})"
+        self.app.push_screen(LogPeekScreen(log_path, settings.PEEK_LINES, title))
+
+    def action_peek_stdout(self) -> None:
+        """Peek at the last N lines of STDOUT."""
+        self._peek_log(is_std_out=True)
+
+    def action_peek_stderr(self) -> None:
+        """Peek at the last N lines of STDERR."""
+        self._peek_log(is_std_out=False)
 
     def action_settings(self) -> None:
         """Show the settings."""

--- a/src/slurmtui/screens/resources.py
+++ b/src/slurmtui/screens/resources.py
@@ -8,6 +8,7 @@ from textual.containers import VerticalScroll
 from textual.css.query import NoMatches
 from textual.events import Key
 from textual.screen import ModalScreen
+from textual.timer import Timer
 from textual.widgets import Footer, Header, Static
 
 from ..slurm_utils import (
@@ -208,6 +209,7 @@ class PartitionDetailScreen(ModalScreen):
     """Detail view showing all nodes in a partition with job info."""
 
     BINDINGS = [
+        Binding("ctrl+r", "force_refresh", "Force Refresh", key_display="Ctrl+R"),
         Binding("i", "info", "Job Info", key_display="I"),
         Binding("escape", "screen.dismiss", "Go Back", key_display="Esc"),
         Binding("q", "quit", "Quit", key_display="Q"),
@@ -230,16 +232,48 @@ class PartitionDetailScreen(ModalScreen):
         self.settings = settings
         # Ordered list of node names matching table rows
         self._node_names: list[str] = []
+        self._refresh_timer: Timer | None = None
 
-    def compose(self) -> ComposeResult:
-        yield Header(show_clock=True)
-        yield SortableDataTable(zebra_stripes=True, id="partition_detail_table")
-        yield Footer()
+    def _refresh_interval(self) -> int:
+        return self.settings.UPDATE_INTERVAL
 
-    def on_mount(self) -> None:
-        self.app.title = f"SlurmTUI: {self.partition_name}"
+    def _refresh_content(self) -> None:
+        resources = get_resources(self.settings)
+        if isinstance(resources, CommandNotFoundError):
+            self.notify(
+                f"Could not refresh resources: {resources.message}", severity="error"
+            )
+            return
+        if not resources:
+            self.notify("No resource information available", severity="warning")
+            return
 
+        partition_data = resources.get(self.partition_name)
+        if partition_data is None:
+            self.notify(
+                f"Partition {self.partition_name} is no longer available",
+                severity="warning",
+            )
+            self.dismiss()
+            return
+
+        all_jobs = get_running_jobs(settings=self._get_all_jobs_settings())
+        if isinstance(all_jobs, CommandNotFoundError):
+            all_jobs = None
+
+        self.data = partition_data
+        self.node_to_jobs = build_node_to_jobs(all_jobs)
+        self._render_table()
+
+    def _update_content(self) -> None:
+        self._refresh_content()
+        self._refresh_timer = self.set_timer(
+            self._refresh_interval(), self._update_content
+        )
+
+    def _render_table(self) -> None:
         table = self.query_one(SortableDataTable)
+        table.clear(columns=True)
         table.cursor_type = "row"
 
         has_gres = any(ng["gres"] for ng in self.data["node_groups"])
@@ -271,7 +305,6 @@ class PartitionDetailScreen(ModalScreen):
             )
             state_col = _state_color(ng["state"])
 
-            # Cross-reference with running jobs
             jobs_on_node = self.node_to_jobs.get(node_name, [])
             if jobs_on_node:
                 job_ids = ", ".join(str(j["job_id"]) for j in jobs_on_node)
@@ -297,6 +330,30 @@ class PartitionDetailScreen(ModalScreen):
             row.extend([job_ids, users, names])
 
             table.add_row(*row, key=node_name)
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        yield SortableDataTable(zebra_stripes=True, id="partition_detail_table")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.title = f"SlurmTUI: {self.partition_name}"
+        self._refresh_content()
+        self._refresh_timer = self.set_timer(
+            self._refresh_interval(), self._update_content
+        )
+
+    def on_unmount(self) -> None:
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+
+    def action_force_refresh(self) -> None:
+        self.notify(
+            "Refreshing partition details...", severity="information", timeout=1.5
+        )
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+        self._update_content()
 
     def action_info(self) -> None:
         """Show full job info for the job running on the selected node."""
@@ -352,6 +409,7 @@ class PartitionDetailScreen(ModalScreen):
 class ResourcesScreen(ModalScreen):
 
     BINDINGS = [
+        Binding("ctrl+r", "force_refresh", "Force Refresh", key_display="Ctrl+R"),
         Binding("escape", "screen.dismiss", "Go Back", key_display="Esc"),
         Binding("q", "quit", "Quit", key_display="Q"),
     ]
@@ -361,48 +419,87 @@ class ResourcesScreen(ModalScreen):
     def __init__(self, settings: SETTINGS, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.settings = settings
+        self._refresh_timer: Timer | None = None
+
+    def _refresh_interval(self) -> int:
+        return self.settings.UPDATE_INTERVAL
+
+    def _refresh_content(self) -> None:
+        resources = get_resources(self.settings)
+
+        try:
+            container = self.query_one("#partitions_container", VerticalScroll)
+        except NoMatches:
+            return
+
+        container.remove_children()
+
+        if isinstance(resources, CommandNotFoundError):
+            container.mount(Static(f"[red]Error: {resources.message}[/red]"))
+            self.app.title = "SlurmTUI Resources"
+            return
+
+        if not resources:
+            container.mount(
+                Static("[yellow]No resource information available[/yellow]")
+            )
+            self.app.title = "SlurmTUI Resources"
+            return
+
+        all_jobs_settings = deepcopy(self.settings)
+        all_jobs_settings.CHECK_ALL_JOBS = True
+        all_jobs = get_running_jobs(settings=all_jobs_settings)
+        if isinstance(all_jobs, CommandNotFoundError):
+            all_jobs = None
+        node_to_jobs = build_node_to_jobs(all_jobs)
+
+        has_gpus = any(p["gpus_total"] > 0 for p in resources.values())
+        for name in sorted(resources):
+            container.mount(
+                PartitionCard(
+                    name,
+                    resources[name],
+                    has_gpus,
+                    node_to_jobs,
+                    self.settings,
+                )
+            )
+
+        self.app.title = f"SlurmTUI Resources: {len(resources)} partitions"
+
+        cards = self.query(PartitionCard)
+        if cards:
+            cards.first().focus()
+
+    def _update_content(self) -> None:
+        self._refresh_content()
+        self._refresh_timer = self.set_timer(
+            self._refresh_interval(), self._update_content
+        )
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
 
-        resources = get_resources(self.settings)
-
-        if isinstance(resources, CommandNotFoundError):
-            yield Static(f"[red]Error: {resources.message}[/red]")
-        elif not resources:
-            yield Static("[yellow]No resource information available[/yellow]")
-        else:
-            # Fetch all running jobs to cross-reference nodes
-            all_jobs_settings = deepcopy(self.settings)
-            all_jobs_settings.CHECK_ALL_JOBS = True
-            all_jobs = get_running_jobs(settings=all_jobs_settings)
-            if isinstance(all_jobs, CommandNotFoundError):
-                all_jobs = None
-            node_to_jobs = build_node_to_jobs(all_jobs)
-
-            has_gpus = any(p["gpus_total"] > 0 for p in resources.values())
-            with VerticalScroll():
-                for name in sorted(resources):
-                    yield PartitionCard(
-                        name,
-                        resources[name],
-                        has_gpus,
-                        node_to_jobs,
-                        self.settings,
-                    )
+        with VerticalScroll(id="partitions_container"):
+            yield Static("[dim]Loading resources...[/dim]")
 
         yield Footer()
 
     def on_mount(self) -> None:
-        resources = get_resources(self.settings)
-        if resources and not isinstance(resources, CommandNotFoundError):
-            self.app.title = f"SlurmTUI Resources: {len(resources)} partitions"
-        else:
-            self.app.title = "SlurmTUI Resources"
-        # Focus the first card for keyboard navigation
-        cards = self.query(PartitionCard)
-        if cards:
-            cards.first().focus()
+        self._refresh_content()
+        self._refresh_timer = self.set_timer(
+            self._refresh_interval(), self._update_content
+        )
+
+    def on_unmount(self) -> None:
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+
+    def action_force_refresh(self) -> None:
+        self.notify("Refreshing resources...", severity="information", timeout=1.5)
+        if self._refresh_timer is not None:
+            self._refresh_timer.stop()
+        self._update_content()
 
     def action_quit(self) -> None:
         from ..slurm_utils import SlurmTUIReturn

--- a/src/slurmtui/screens/settings.py
+++ b/src/slurmtui/screens/settings.py
@@ -141,6 +141,15 @@ class SettingsScreen(ModalScreen[bool]):
                 )
 
             with Horizontal(classes="settings_row"):
+                yield Label("Peek Lines", classes="settings_label")
+                yield Input(
+                    str(settings.PEEK_LINES),
+                    id="input_PEEK_LINES",
+                    placeholder="100",
+                    tooltip="Number of lines to show in the log peek popup (Space / Ctrl+Space)",
+                )
+
+            with Horizontal(classes="settings_row"):
                 yield Label("Old Jobs Start Time", classes="settings_label")
                 yield Input(
                     settings.OLD_JOBS_START_TIME,
@@ -230,6 +239,12 @@ class SettingsScreen(ModalScreen[bool]):
             settings.TAIL_LINES = max(1, int(tail_lines_str))
         except (ValueError, TypeError):
             settings.TAIL_LINES = 10000
+
+        peek_lines_str = self.query_one("#input_PEEK_LINES", Input).value.strip()
+        try:
+            settings.PEEK_LINES = max(1, int(peek_lines_str))
+        except (ValueError, TypeError):
+            settings.PEEK_LINES = 100
 
         # Strings with fallback to defaults
         start = self.query_one("#input_OLD_JOBS_START_TIME", Input).value.strip()

--- a/src/slurmtui/utils.py
+++ b/src/slurmtui/utils.py
@@ -63,6 +63,10 @@ class SETTINGS:
         default=10000,
         metadata="Number of lines to show when tailing logs",
     )
+    PEEK_LINES: int = field(
+        default=50,
+        metadata="Number of lines to show in the log peek popup (Space / Ctrl+Space)",
+    )
     OLD_JOBS_END_TIME: str = field(
         default="now",
         metadata="End time for old jobs query (sacct time format)",
@@ -161,7 +165,7 @@ class SETTINGS:
                 f"{data['SECONDARY_TEXT_UTIL_CMD']} {{log_path}}"
             )
 
-        for key in ("TAIL_LINES",):
+        for key in ("TAIL_LINES", "PEEK_LINES"):
             try:
                 data[key] = max(1, int(data[key]))
             except (TypeError, ValueError):

--- a/src/slurmtui/utils.py
+++ b/src/slurmtui/utils.py
@@ -64,7 +64,7 @@ class SETTINGS:
         metadata="Number of lines to show when tailing logs",
     )
     PEEK_LINES: int = field(
-        default=50,
+        default=100,
         metadata="Number of lines to show in the log peek popup (Space / Ctrl+Space)",
     )
     OLD_JOBS_END_TIME: str = field(
@@ -187,7 +187,11 @@ class SETTINGS:
                 data[key] = None
 
         # Optional str
-        for key in ("DEBUG_SQUEUE_JSON_PATH", "DEBUG_SACCT_JSON_PATH", "DEBUG_SINFO_JSON_PATH"):
+        for key in (
+            "DEBUG_SQUEUE_JSON_PATH",
+            "DEBUG_SACCT_JSON_PATH",
+            "DEBUG_SINFO_JSON_PATH",
+        ):
             v = data.get(key)
             if v is not None and not isinstance(v, str):
                 data[key] = None


### PR DESCRIPTION
This pull request adds a new "log peek" feature, allowing users to quickly preview the last N lines of job log files (STDOUT/STDERR) in a popup via keyboard shortcuts (Space/Ctrl+Space). It also introduces a "Force Refresh" action (Ctrl+R) for job and resource tables, and makes the number of lines shown in the log peek popup configurable in the settings. The implementation touches several screens and the settings logic to provide a more interactive and customizable user experience.

**Log Peek Feature:**

* Added `LogPeekScreen` modal, which displays the last N lines of a log file in a popup, accessible by pressing Space or Ctrl+Space on job tables. The number of lines is configurable via settings. (`src/slurmtui/screens/log_peek.py`, `src/slurmtui/main.py`, `src/slurmtui/screens/old_jobs.py`, `src/slurmtui/screens/__init__.py`, `src/slurmtui/screens/settings.py`, `src/slurmtui/utils.py`) [[1]](diffhunk://#diff-37e04bd697d4ac7c3914ed5335cd5e26195030beefce266c7cff090e713cca54R1-R58) [[2]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR20) [[3]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR364-R406) [[4]](diffhunk://#diff-4cc08ec363ac74fdd9067de1397b0a9983c3e0ba8fb6eb59825d8b99c0431493R13) [[5]](diffhunk://#diff-4cc08ec363ac74fdd9067de1397b0a9983c3e0ba8fb6eb59825d8b99c0431493R95-R96) [[6]](diffhunk://#diff-4cc08ec363ac74fdd9067de1397b0a9983c3e0ba8fb6eb59825d8b99c0431493R298-R347) [[7]](diffhunk://#diff-2f4c0938a9783dbc2a55b4b5358f2528f148249f31ec64eb078a0cf45368d71cR143-R151) [[8]](diffhunk://#diff-017298cf0570e02cef84da7dbab850c301b80bd7dcfc49e352b318025f5f2f4fR66-R69)

* Added keyboard bindings for "Peek STDOUT" (Space) and "Peek STDERR" (Ctrl+Space) in both the main and old jobs screens. [[1]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR73-R77) [[2]](diffhunk://#diff-4cc08ec363ac74fdd9067de1397b0a9983c3e0ba8fb6eb59825d8b99c0431493R95-R96)

**Force Refresh Actions:**

* Implemented "Force Refresh" (Ctrl+R) in job and resource screens, allowing users to manually refresh job/resource tables and reset their update timers. (`src/slurmtui/main.py`, `src/slurmtui/screens/resources.py`) [[1]](diffhunk://#diff-dca5e67d4372e801a87b0205fd04667d2e1bdb9bf7c014008541a7da444d94beR236-R242) F63d6364L209R209, [[2]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446R334-R357) [[3]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446R412)

**Resource and Partition Table Refactoring:**

* Refactored resource and partition detail screens to support periodic and manual refresh, including timer management and improved data reloading logic. (`src/slurmtui/screens/resources.py`) [[1]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446R11) [[2]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446R235-R276) [[3]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446L384-R503) [[4]](diffhunk://#diff-ffe30147466c56974fae534e4fecb7bac9873222c002f64bca878a91969a9446R422-R448)

**Settings and Validation:**

* Added `PEEK_LINES` to settings, exposed it in the settings UI, and ensured input validation for this new field. (`src/slurmtui/screens/settings.py`, `src/slurmtui/utils.py`) [[1]](diffhunk://#diff-2f4c0938a9783dbc2a55b4b5358f2528f148249f31ec64eb078a0cf45368d71cR143-R151) [[2]](diffhunk://#diff-2f4c0938a9783dbc2a55b4b5358f2528f148249f31ec64eb078a0cf45368d71cR243-R248) [[3]](diffhunk://#diff-017298cf0570e02cef84da7dbab850c301b80bd7dcfc49e352b318025f5f2f4fR66-R69) [[4]](diffhunk://#diff-017298cf0570e02cef84da7dbab850c301b80bd7dcfc49e352b318025f5f2f4fL164-R168)

These changes enhance usability by giving users quick log previews and more control over data refresh and display customization.